### PR TITLE
build: declare our actual requirement on Python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-""" Setup for g2p
+""" Setup for wav2vec2aligner
 """
 import datetime as dt
 from os import path
@@ -14,7 +14,7 @@ with open(path.join(this_directory, "requirements.txt"), encoding="utf8") as f:
 
 setup(
     name="ctc-segmentation-aligner",
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     version="1.0",
     author="Aidan Pine",
     author_email="hello@aidanpine.ca",


### PR DESCRIPTION
We use torchaudio 2.1.0 which requires Python 3.8. We prefer 3.10 but don't actually depend on it yet for this repo, so we can declare it at >=3.8.