### PR TITLE
docs: declare our license, MIT, and clarify the role of the tutorial

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 National Research Council Canada
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Language-level Zero-Shot Wav2Vec2 Aligner with input preservation
 
-An aligner based on Wav2Vec2 and [ctc segmentation](https://github.com/lumaku/ctc-segmentation). Most of the code is from [this tutorial](https://pytorch.org/audio/main/tutorials/forced_alignment_for_multilingual_data_tutorial.html) but uses [g2p](https://github.com/roedoejet/g2p) for preserving the input, turned into a package with a command line interface with a method for exporting to TextGrid.
+An aligner based on Wav2Vec2 and [ctc segmentation](https://github.com/lumaku/ctc-segmentation). Most of the code was created by following [this tutorial](https://pytorch.org/audio/main/tutorials/forced_alignment_for_multilingual_data_tutorial.html) but uses [g2p](https://github.com/roedoejet/g2p) for preserving the input, turned into a package with a command line interface with a method for exporting to TextGrid.
 
 ## Install
 


### PR DESCRIPTION
Aidan, please review my statement about the role of the tutorial. Comparing our code and the tutorial, nearly no actual code remains as in the tutorial, what remain are the concepts, which means we can accurately call this code ©NRC.