### PR TITLE
fix: adjust where g2p imports need to come from now

### DIFF
--- a/aligner/utils.py
+++ b/aligner/utils.py
@@ -19,7 +19,9 @@ class TextHash(dict):
 
 def create_transducer(text, labels_dictionary, debug=False):
     # deferred expensive imports
-    from g2p import CompositeTransducer, Mapping, Transducer, make_g2p
+    from g2p import make_g2p
+    from g2p.mappings import Mapping
+    from g2p.transducer import CompositeTransducer, Transducer
 
     text = text.lower()
     allowable_chars = labels_dictionary.keys()


### PR DESCRIPTION
When we optimized the g2p CLI to load fast, we removed a number of imports from g2p.__init__, so now we have to import those symbols from where they are actually defined.

Fixes: https://github.com/roedoejet/EveryVoice/issues/323