### PR TITLE
fix(deps): make this module compatible with typer 0.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,6 @@ torch>=2.1.0
 torchaudio>=2.1.0
 g2p>=1.0.20230417
 pympi-ling
-typer[all]>=0.9.0
+typer>=0.9.0
+rich>=10.11.0
+shellingham>=1.3.0


### PR DESCRIPTION
typer 0.12 no longer supports the [all] extras, they're now just part of the default dependencies.  To get them for typer < 0.12 and yet be compatible with 0.12 too, all we need to do is add rich and shellingham explicitly ourselves.

The version specification I chose for rich and shellingham are those in the current main branch of typer itself. These are very relaxed too, allowing pretty much any version in the last 3 or 4 years.

<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Prepare the way to make EV compatible with typer 0.12, so we're not so tightly locked to an old version.

### Related PRs?

https://github.com/roedoejet/clipdetect/pull/3