### PR TITLE
feat: add segment extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ Create a conda env, then `pip install -e .`
 
 ## Usage
 
-`ctc-segmenter sample.txt sample.wav` which will output a [Praat TextGrid](https://www.fon.hum.uva.nl/praat/) with the word, and sentence level alignments.
+`ctc-segmenter align-single sample.txt sample.wav` which will output a [Praat TextGrid](https://www.fon.hum.uva.nl/praat/) with the word, and sentence level alignments.
+
+You can then adjust the Praat TextGrid as necessary and run `ctc-segmenter extract-segments-from-textgrid sample.TextGrid sample.wav outdir` which will extract the segments and write them to the `outdir` directory along with a metadata file.

--- a/aligner/cli.py
+++ b/aligner/cli.py
@@ -30,7 +30,7 @@ def extract_segments_from_textgrid(
         ..., exists=True, file_okay=True, dir_okay=False, autocompletion=complete_path
     ),
     outdir: Path = typer.Argument(
-        ..., exists=True, file_okay=False, dir_okay=True, autocompletion=complete_path
+        ..., exists=False, file_okay=False, dir_okay=True, autocompletion=complete_path
     ),
     tier_number: int = typer.Option(
         4, help="The index of the tier to extract intervals from."

--- a/aligner/cli.py
+++ b/aligner/cli.py
@@ -10,10 +10,19 @@ from .utils import (
     read_text,
 )
 
+CLI_LONG_HELP = """
+    # Segment Help
+
+        - **align** --- This command will align a long audio file with some text into words and sentences.
+
+        - **extract** --- This command will take the alignment from the `align` command and extract it into multiple utterances in the format required for training a TTS system
+    """
+
 app = typer.Typer(
     pretty_exceptions_show_locals=False,
     context_settings={"help_option_names": ["-h", "--help"]},
-    help="An alignment tool based on CTC segmentation to split long audio into utterances",
+    rich_markup_mode="markdown",
+    help=CLI_LONG_HELP,
 )
 
 
@@ -21,7 +30,22 @@ def complete_path():
     return []
 
 
-@app.command()
+# We put this here for easy import into other modules that consume
+# the aligner, like EveryVoice
+EXTRACT_SEGMENTS_LONG_HELP = """
+    # Segmentation help
+
+    This command will take the alignment from the `align` command and extract it into multiple utterances in the format required for training a TTS system.
+    """
+
+EXTRACT_SEGMENTS_SHORT_HELP = "Extract the intervals from a TextGrid"
+
+
+@app.command(
+    name="extract",
+    help=EXTRACT_SEGMENTS_LONG_HELP,
+    short_help=EXTRACT_SEGMENTS_SHORT_HELP,
+)
 def extract_segments_from_textgrid(
     text_grid_path: Path = typer.Argument(
         ..., exists=True, file_okay=True, dir_okay=False, autocompletion=complete_path
@@ -79,7 +103,21 @@ def extract_segments_from_textgrid(
     )
 
 
-@app.command()
+# We put this here for easy import into other modules that consume
+# the aligner, like EveryVoice
+ALIGN_SINGLE_LONG_HELP = """
+    # Segmentation help
+
+    This command will align a long audio file with some text.
+    This command should work on most languages and you should run it before running the new project or preprocessing steps.
+    This command will create a Praat TextGrid file. You must install Praat (https://www.fon.hum.uva.nl/praat/) if you want to inspect the alignments.
+    """
+ALIGN_SINGLE_SHORT_HELP = "Align a long audio file with some text"
+
+
+@app.command(
+    name="align", help=ALIGN_SINGLE_LONG_HELP, short_help=ALIGN_SINGLE_SHORT_HELP
+)
 def align_single(
     text_path: Path = typer.Argument(
         ..., exists=True, file_okay=True, dir_okay=False, autocompletion=complete_path


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

Extract the audio and text from a textgrid into something usable by EveryVoice

### Fixes? <!-- List any issues this PR fixes, e.g. Fixes #42, Fixes #324 -->

N/A

### Feedback sought? <!-- What should reviewers focus on in particular? -->

Sanity. Suggest any changes to the CLI method names or documentation.

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

Medium

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->



### How to test? <!-- Explain how reviewers should test this PR. -->

For this to work you need a plain text transcript and some corresponding audio. You can then run the segmenter: `everyvoice segment align path_to_text.txt path_to_audio.wav`. You can then install [Praat](https://www.fon.hum.uva.nl/praat/) and use it to inspect the .TextGrid file that was generated, and adjust any alignments as necessary. Once you are happy with your alignments, you can use `everyvoice segment extract path_to_alignment.TextGrid path_to_audio.wav outdir` which will then create a folder called `outdir` with your audio, and a metadata file containing references to each of your audio files and the corresponding text.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

medium

### Version change? <!-- Do you think this PR should trigger a Major (Breaking Change)/Minor (New Feature)/patch (refactor/bug fix) version change? -->

minor

### Related PRs? <!-- List PRs in other repos related to this PR, if any. -->

TBD

<!-- Add any other relevant information here -->
