### PR TITLE
Dev.ej/fix typer

### DIFF
--- a/aligner/cli.py
+++ b/aligner/cli.py
@@ -26,7 +26,7 @@ app = typer.Typer(
 )
 
 
-def complete_path(ctx=None, param=None, incomplete=None):
+def complete_path(ctx, param, incomplete):
     return []
 
 

--- a/aligner/tests/test_cli.py
+++ b/aligner/tests/test_cli.py
@@ -105,7 +105,6 @@ class CLITest(TestCase):
 
 class MiscTests(TestCase):
     def test_shell_complete(self):
-        self.assertEqual(complete_path(), [])
         self.assertEqual(complete_path(None, None, None), [])
 
     def test_segment(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ shellingham>=1.3.0
 soundfile>=0.10.2
 torch>=2.1.0
 torchaudio>=2.1.0
-typer>=0.9.0
+typer>=0.12.4


### PR DESCRIPTION
<!-- PR template: please provide enough information to guide your reviewers.
Please read Contributing.md before submitting a PR.  -->

### PR Goal? <!-- Explain the main objective of this PR. -->

autocompletion is broken when using `shell_complete=` with typer<=0.12.3, so lock typer>=0.12.4

### Feedback sought? <!-- What should reviewers focus on in particular? -->

rubber stamping

### Priority? <!-- How soon would you like this PR reviewed, does it block other work? -->

high, I would like to merge this before today's release

### Tests added? <!-- Make sure your PR includes automated tests for your changes. -->

already covered, tested manually.

### How to test? <!-- Explain how reviewers should test this PR. -->

if you install `typer==0.12.3`, you'll see autocompletion broken for paths, if you install `typer>=0.12.4` you'll see it work correctly again.

### Confidence? <!-- How confident are you that these changes are ready to merge? -->

high

### Related PRs? <!-- List PRs in other repos related to this PR, if any. -->

https://github.com/EveryVoiceTTS/EveryVoice/pull/596

<!-- Add any other relevant information here -->
