### PR TITLE
build: configure isort correctly in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [isort]
-known_first_party = dfaligner
+known_first_party = aligner
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
Related to https://github.com/EveryVoiceTTS/EveryVoice/pull/687 because I removed the wrong reference to dfaligner in this module's isort config.